### PR TITLE
Use unused constant BASE_PREFIX in middleware.ts

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -25,11 +25,10 @@ export function middleware(request: NextRequest) {
 	// 針對 GET & POST 請求紀錄日誌
 	if (method === "GET") {
 		console.log(`[GET Request] URL: ${url}`);
-	} 
+	}
 	if (method === "POST") {
 		console.log(`[POST Request] URL: ${url}`);
 	}
-
 
 	// 設定 CORS Headers
 	const origin = request.headers.get("origin");
@@ -47,5 +46,5 @@ export function middleware(request: NextRequest) {
 
 // 只影響的路徑
 export const config = {
-	matcher: ["/api/:path*", `/JSONID_:path*`],
+	matcher: ["/api/:path*", `/${BASE_PREFIX}:path*`],
 };


### PR DESCRIPTION
I notice that the `BASE_PREFIX` constant was imported but not used in middlware.ts. This PR updates the code to use `BASE_PREFIX`

Feel Free to let me know if any adjustments are needed!